### PR TITLE
Remove Microsoft Online Services Sing-In Assistant from instructions

### DIFF
--- a/Instructions/Labs/LAB_AK_02_Lab2_Ex4_Manage_Users_with_PS.md
+++ b/Instructions/Labs/LAB_AK_02_Lab2_Ex4_Manage_Users_with_PS.md
@@ -10,31 +10,7 @@ Once the Microsoft Online Services Sign-In Assistant is installed, you will  use
 
 ### Task 1 - Installing Microsoft Azure Active Directory module for Windows PowerShell
 
-In this task you are going to lay the foundation for editing and managing the Microsoft 365 tenant with the use of PowerShell. The next step is to install the Microsoft Online Services Sign-In Assistant, which provides end user sign-in capabilities to Microsoft Online Services, such as Microsoft 365. 
-
-The Microsoft Online Services Sign-In Assistant installs client components that allow common applications, such as Microsoft Outlook, to authenticate to Microsoft Online Services. The Microsoft Online Services Sign-In Assistant can also provide an improved sign-in experience, such that end users can access Microsoft Online Services without having to re-enter their credentials (such as a user name or password). This download is intended for IT professionals for distribution to managed client systems as part of a Microsoft 365 client deployment through System Center Configuration Manager (SCCM) or similar software distribution systems.
-
 1. You should still be logged into the **LON-CL1** VM as the **Administrator** account with a password of **Pa55w.rd**.
-
-2. Your **Edge** browser should still be open from the prior lab exercise. You should be logged into Microsoft 365 as Holly Dickson, and the browser should have tabs open for the **Microsoft Office Home** page and the **Microsoft 365 admin center**. <br>
-
-	Open a new tab in your browser and then enter the following URL in the address bar: **http://aka.ms/t01i1o**
-
-3. This will take you to the **Microsoft Download Center** for the **Microsoft Online Services Sign-In Assistant for IT Professionals RTW**. Select the **Download** button.
-
-4. On the **Choose the download you want** page, select the **msoidcli_64.msi** check box and then Select **Next**.
-
-5. In the notification bar that appears at the bottom of the page, once the **msoidcli_64.msi** file is saved, select **Open file**. 
-
-6. On the **Do you want to run this file?** dialog box, select **Run**.
-
-7. In the **Microsoft Online Services Sign-in Assistant Setup** wizard, select **I accept the terms in the License Agreement and Privacy Statement**, and then Select **Install**.
-
-8. If a **Do you want to allow this app to make changes to your device** dialog box appears, select **Yes**.
-
-9. On the **Completed the Microsoft Online Services Sign-in Assistant Setup Wizard** page, select **Finish**.
-
-10. Close the tab in your Edge browser for the **Download Center**.
 
 11. In the Search box in the bottom left corner of your taskbar, enter **powershell**. 
 


### PR DESCRIPTION
# Module: Module 2
## Lab/Demo:  Lab 2, Exercise 4 Task 1, Steps 2-10

Fixes # .

Changes proposed in this pull request:

-Remove information and instructions to download and install the Microsoft online services sign-in assistant.
-No longer available at the provided link.
-Not needed on Windows 8 and newer OS.